### PR TITLE
Gno debugging section

### DIFF
--- a/003-debug-gno-code/README.md
+++ b/003-debug-gno-code/README.md
@@ -25,7 +25,9 @@ The test will fail, because `Pop` and `Push` are currently not
 implemented -- if you open the `queue.gno` file, you will see
 that they just contain two `// TODO` comments.
 
-- Implement `Pop` and `Push`
+- Implement `Pop` and `Push`. These need to implement a
+  FIFO (First In, First Out) queue -- so the last element added
+  using `Push` will be the first one to be removed using `Pop`.
 - Run the test again until it succeeds 
 
 <details>

--- a/003-debug-gno-code/README.md
+++ b/003-debug-gno-code/README.md
@@ -1,0 +1,23 @@
+# Debugging Gno code
+
+In this section, you will learn to debug your Gno contract. As contracts aren't
+modifiable, it is crucial to debug them properly before their publication to
+the blockchain.
+
+As you will see Gno debugging is pretty much the same as Go debugging.
+
+- `queue.gno` in this section implements a basic FIFO queue with 2 functions
+`Push` and `Pop`.
+- `queue_test.gno` contains a test that asserts the expected behavior of `Pop` and
+`Push`.
+
+## Steps
+
+- Run the test:
+```
+$ gno test . -verbose -run TestQueue
+```
+The test fails because `Pop` and `Push` are not implemented properly.
+
+- Implement `Pop` and `Push`
+- Run the test again until it succeeds 

--- a/003-debug-gno-code/README.md
+++ b/003-debug-gno-code/README.md
@@ -11,8 +11,7 @@ the kind `func TestXxx(t *testing.T)` is automatically added as a test,
 run when using `gno test`. If the function calls `t.Errorf`, then it is
 considered failed.
 
-- `queue.gno` in this section implements a basic FIFO queue with 2 functions
-`Push` and `Pop`.
+- `queue.gno`, in this tutorial's directory `003-debug-gno-code`, is a source file containing 2 stub functions `Push` and `Pop`. Your goal in this tutorial is to implement them correctly and see the tests succeed.
 - `queue_test.gno` contains a test that asserts the expected behavior of `Pop` and
 `Push`.
 

--- a/003-debug-gno-code/README.md
+++ b/003-debug-gno-code/README.md
@@ -12,8 +12,8 @@ run when using `gno test`. If the function calls `t.Errorf`, then it is
 considered failed.
 
 - `queue.gno`, in this tutorial's directory `003-debug-gno-code`, is a source file containing 2 stub functions `Push` and `Pop`. Your goal in this tutorial is to implement them correctly and see the tests succeed.
-- `queue_test.gno` contains a test that asserts the expected behavior of `Pop` and
-`Push`.
+- `queue_test.gno` contains a test that checks the behavior of `Pop` and `Push`.
+  If you implement them correctly, running `gno test` will succeed without errors.
 
 ## Steps
 

--- a/003-debug-gno-code/README.md
+++ b/003-debug-gno-code/README.md
@@ -21,7 +21,9 @@ considered failed.
 ```
 $ gno test . -verbose
 ```
-The test fails because `Pop` and `Push` are not implemented properly.
+The test will fail, because `Pop` and `Push` are currently not
+implemented -- if you open the `queue.gno` file, you will see
+that they just contain two `// TODO` comments.
 
 - Implement `Pop` and `Push`
 - Run the test again until it succeeds 

--- a/003-debug-gno-code/README.md
+++ b/003-debug-gno-code/README.md
@@ -21,3 +21,23 @@ The test fails because `Pop` and `Push` are not implemented properly.
 
 - Implement `Pop` and `Push`
 - Run the test again until it succeeds 
+
+<details>
+    <summary>Solution (only if you're stuck!)</summary>
+
+```
+func Push(s string) {
+    q = append(q, s)
+}
+
+func Pop() string {
+    if len(q) == 0 {
+        return ""
+    }
+    s := q[0]
+    q = q[1:]
+    return s
+}
+```
+
+</details>

--- a/003-debug-gno-code/README.md
+++ b/003-debug-gno-code/README.md
@@ -4,7 +4,12 @@ In this section, you will learn to debug your Gno contract. As contracts aren't
 modifiable, it is crucial to debug them properly before their publication to
 the blockchain.
 
-As you will see Gno debugging is pretty much the same as Go debugging.
+Debugging Gno code functions in many ways as in Go;
+the biggest tool at our disposal are test files. These are identified
+as source files whose names end with `_test.go`. Every function of
+the kind `func TestXxx(t *testing.T)` is automatically added as a test,
+run when using `gno test`. If the function calls `t.Errorf`, then it is
+considered failed.
 
 - `queue.gno` in this section implements a basic FIFO queue with 2 functions
 `Push` and `Pop`.

--- a/003-debug-gno-code/README.md
+++ b/003-debug-gno-code/README.md
@@ -25,7 +25,7 @@ The test fails because `Pop` and `Push` are not implemented properly.
 <details>
     <summary>Solution (only if you're stuck!)</summary>
 
-```
+```go
 func Push(s string) {
     q = append(q, s)
 }

--- a/003-debug-gno-code/README.md
+++ b/003-debug-gno-code/README.md
@@ -19,7 +19,7 @@ considered failed.
 
 - Run the test:
 ```
-$ gno test . -verbose -run TestQueue
+$ gno test . -verbose
 ```
 The test fails because `Pop` and `Push` are not implemented properly.
 

--- a/003-debug-gno-code/queue.gno
+++ b/003-debug-gno-code/queue.gno
@@ -1,0 +1,15 @@
+package queue
+
+var q []string
+
+// Push appends s to q.
+func Push(s string) {
+	// TODO
+}
+
+// Pop removes the first element of q and returns it.
+// If q is empty, Pop returns an empty string.
+func Pop() string {
+	// TODO
+	return ""
+}

--- a/003-debug-gno-code/queue_test.gno
+++ b/003-debug-gno-code/queue_test.gno
@@ -1,0 +1,17 @@
+package queue
+
+import "testing"
+
+func TestQueue(t *testing.T) {
+	// Push 2 items
+	Push("alice")
+	Push("bob")
+	// Call Pop() 3 times
+	// Third time should return an empty string because the queue is empty
+	for i, expected := range []string{"alice", "bob", ""} {
+		res := Pop()
+		if res != expected {
+			t.Errorf("Pop()#%d want %q, got %q", i, expected, res)
+		}
+	}
+}


### PR DESCRIPTION
Adds the third section about gno debugging.

I wasn't able to test `_filetest.gno` file in this arborescence, the error is `gno test` doesn't recognize the import path `gno.land/r/demo/getting-started`. As a result, no `_filetest` and no `Render` function in this section.

<a href="https://gitpod.io/#https://github.com/gnolang/getting-started/pull/14"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

