### PR TITLE
gnomod bug demo

### DIFF
--- a/003_debug_gno_code/queue_filetest.gno
+++ b/003_debug_gno_code/queue_filetest.gno
@@ -1,0 +1,11 @@
+package main
+
+import queue "gno.land/r/demo/getting_started/003_debug_gno_code"
+
+func main() {
+	println(42, 44)
+	_ = queue.Pop
+}
+
+// Output:
+// 42 44

--- a/003_debug_gno_code/queue_test.gno
+++ b/003_debug_gno_code/queue_test.gno
@@ -3,6 +3,7 @@ package queue
 import "testing"
 
 func TestQueue(t *testing.T) {
+  return
 	// Push 2 items
 	Push("alice")
 	Push("bob")


### PR DESCRIPTION
DO NOT MERGE

It appears that the code is functioning correctly without any imports. However, when trying to import the current directory, as defined in the gno.mod file, the following error is encountered:

```
❯ go run github.com/gnolang/gno/gnovm/cmd/gno test .
panic: fail on queue_filetest.gno: got unexpected error: main/queue_filetest.gno:1: unknown import path gno.land/r/demo/getting_started/003_debug_gno_code

goroutine 1 [running]:
github.com/gnolang/gno/gnovm/tests.RunFileTest({0x140000420c0, 0x50}, {0x140001bc450, 0x12}, {0x1400045b9b0, 0x1, 0x0?})
        /Users/moul/go/pkg/mod/github.com/gnolang/gno@v0.0.0-20230723112528-4df47de0731a/gnovm/tests/file.go:286 +0x984
main.gnoTestPkg({0x140003945b9, 0x3}, {0x1400018bf90?, 0x1, 0x10284574d?}, {0x1400018bfb0, 0x1, 0x0?}, 0x140001a2c00, 0x14000114230)
        /Users/moul/go/pkg/mod/github.com/gnolang/gno@v0.0.0-20230723112528-4df47de0731a/gnovm/cmd/gno/test.go:326 +0x5a4
main.execTest(0x140001a2c00, {0x1400018be90, 0x1, 0x1}, 0x0?)
        /Users/moul/go/pkg/mod/github.com/gnolang/gno@v0.0.0-20230723112528-4df47de0731a/gnovm/cmd/gno/test.go:205 +0x7f0
main.newTestCmd.func1({0x0?, 0x0?}, {0x1400018be90?, 0x14000110a38?, 0x0?})
        /Users/moul/go/pkg/mod/github.com/gnolang/gno@v0.0.0-20230723112528-4df47de0731a/gnovm/cmd/gno/test.go:48 +0x38
github.com/gnolang/gno/tm2/pkg/commands.(*Command).Run(0x0?, {0x102c104f8?, 0x14000192000?})
        /Users/moul/go/pkg/mod/github.com/gnolang/gno@v0.0.0-20230723112528-4df47de0731a/tm2/pkg/commands/command.go:233 +0x17c
github.com/gnolang/gno/tm2/pkg/commands.(*Command).Run(0x140001106e0?, {0x102c104f8?, 0x14000192000?})
        /Users/moul/go/pkg/mod/github.com/gnolang/gno@v0.0.0-20230723112528-4df47de0731a/tm2/pkg/commands/command.go:237 +0x12c
github.com/gnolang/gno/tm2/pkg/commands.(*Command).ParseAndRun(0x14000180000?, {0x102c104f8, 0x14000192000}, {0x1400018e190?, 0x60?, 0x0?})
        /Users/moul/go/pkg/mod/github.com/gnolang/gno@v0.0.0-20230723112528-4df47de0731a/tm2/pkg/commands/command.go:118 +0x4c
main.main()
        /Users/moul/go/pkg/mod/github.com/gnolang/gno@v0.0.0-20230723112528-4df47de0731a/gnovm/cmd/gno/main.go:14 +0x74
exit status 2
```

It seems that the import path `gno.land/r/demo/getting_started/003_debug_gno_code` is not recognized.

Please check the import statement and the gno.mod file to ensure that the import path is correctly defined and points to the appropriate location. If the issue persists, further investigation might be needed to identify the root cause of the error.